### PR TITLE
Fix error related to missing parameter

### DIFF
--- a/bots.go
+++ b/bots.go
@@ -409,6 +409,7 @@ func (c *DBLClient) PostBotStats(botID string, payload BotStatsPayload) error {
 	}
 
 	req.Header.Set("Authorization", c.token)
+	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.client.Do(req)
 


### PR DESCRIPTION
When "Content-Type" isn't set when posting stats 400 gets returned with "Required parameter server_count or shards missing"