### PR TITLE
Add HTTPClientOption option func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE-specific metadata
+.idea/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.11
+  - 1.14
   - tip
 
 os:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Godoc is available here: https://godoc.org/github.com/DiscordBotList/go-dbl
 - [Guides](#guides)
   - [Installing](#installing)
   - [Posting Stats](#posting-stats)
-  - [Timeout option](#timeout-option)
+  - [Setting options](#setting-options)
   - [Ratelimits](#ratelimits)
   - [Webhook](#webhook)
   - [More details](#more-details)
@@ -36,46 +36,55 @@ go get -u github.com/DiscordBotList/go-dbl
 package main
 
 import (
-	dbl "github.com/DiscordBotList/go-dbl"
+	"log"
+
+	"github.com/DiscordBotList/go-dbl"
 )
 
 func main() {
-	client, err := dbl.NewClient("Token")
-	
+	dblClient, err := dbl.NewClient("token")
 	if err != nil {
-		// Handle error
+		log.Fatalf("Error creating new Discord Bot List client: %s", err)
 	}
-	
-	err = client.PostBotStats("441751906428256277", &BotStatsPayload{
+
+	err = dblClient.PostBotStats("botID", &dbl.BotStatsPayload{
 		Shards: []int{2500}, // If non-sharded, just pass total server count as the only integer element
 	})
-	
 	if err != nil {
-		// Handle error
+		log.Printf("Error sending bot stats to Discord Bot List: %s", err)
 	}
-	
+
 	// ...
 }
 ```
 
-### Timeout option
+### Setting options
 
 ```go
 package main
 
 import (
-	dbl "github.com/DiscordBotList/go-dbl"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/DiscordBotList/go-dbl"
 )
 
+const clientTimeout = 5 * time.Second
+
 func main() {
-	client, err := dbl.NewClient(
-		"Token",
-		dbl.TimeoutOption(time.Second * 5) // Setting timeout option. Default is 3 seconds
+	httpClient := &http.Client{}
+
+	dblClient, err := dbl.NewClient(
+		"token",
+		dbl.HTTPClientOption(httpClient), // Setting a custom HTTP client. Default is *http.Client with default timeout.
+		dbl.TimeoutOption(clientTimeout), // Setting timeout option. Default is 3 seconds
 	)
-	
 	if err != nil {
-		// Handle error
+		log.Fatalf("Error creating new Discord Bot List client: %s", err)
 	}
+
 	// ...
 }
 ```
@@ -94,14 +103,23 @@ If remote rate limit is exceeded, `ErrRemoteRatelimit` error will be returned an
 package main
 
 import (
-	dbl "github.com/DiscordBotList/go-dbl"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/DiscordBotList/go-dbl"
 )
 
-func main() {
-	listener := dbl.NewListener("AuthToken", handleVote)
+const listenerPort = ":9090"
 
-	// blocking call
-	listener.Serve(":9090")
+func main() {
+	listener := dbl.NewListener("token", handleVote)
+
+	// Serve is a blocking call
+	err := listener.Serve(listenerPort)
+	if !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("HTTP server error: %s", err)
+	}
 }
 
 func handleVote(payload *dbl.WebhookPayload) {

--- a/bots.go
+++ b/bots.go
@@ -148,7 +148,7 @@ type BotStatsPayload struct {
 // Information about different bots with an optional filter parameter
 //
 // Use nil if no option is passed
-func (c *DBLClient) GetBots(filter *GetBotsPayload) (*GetBotsResult, error) {
+func (c *Client) GetBots(filter *GetBotsPayload) (*GetBotsResult, error) {
 	if c.token == "" {
 		return nil, ErrRequireAuthentication
 	}
@@ -191,7 +191,7 @@ func (c *DBLClient) GetBots(filter *GetBotsPayload) (*GetBotsResult, error) {
 		req.URL.RawQuery = q.Encode()
 	}
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (c *DBLClient) GetBots(filter *GetBotsPayload) (*GetBotsResult, error) {
 }
 
 // Information about a specific bot
-func (c *DBLClient) GetBot(botID string) (*Bot, error) {
+func (c *Client) GetBot(botID string) (*Bot, error) {
 	if c.token == "" {
 		return nil, ErrRequireAuthentication
 	}
@@ -230,7 +230,7 @@ func (c *DBLClient) GetBot(botID string) (*Bot, error) {
 		return nil, err
 	}
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return nil, err
@@ -258,7 +258,7 @@ func (c *DBLClient) GetBot(botID string) (*Bot, error) {
 // Requires authentication
 //
 // IF YOU HAVE OVER 1000 VOTES PER MONTH YOU HAVE TO USE THE WEBHOOKS AND CAN NOT USE THIS
-func (c *DBLClient) GetVotes(botID string) ([]*User, error) {
+func (c *Client) GetVotes(botID string) ([]*User, error) {
 	if c.token == "" {
 		return nil, ErrRequireAuthentication
 	}
@@ -273,7 +273,7 @@ func (c *DBLClient) GetVotes(botID string) ([]*User, error) {
 		return nil, err
 	}
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func (c *DBLClient) GetVotes(botID string) ([]*User, error) {
 // Use this endpoint to see who have upvoted your bot in the past 24 hours. It is safe to use this even if you have over 1k votes.
 //
 // Requires authentication
-func (c *DBLClient) HasUserVoted(botID, userID string) (bool, error) {
+func (c *Client) HasUserVoted(botID, userID string) (bool, error) {
 	if c.token == "" {
 		return false, ErrRequireAuthentication
 	}
@@ -320,7 +320,7 @@ func (c *DBLClient) HasUserVoted(botID, userID string) (bool, error) {
 
 	req.URL.RawQuery = q.Encode()
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return false, err
@@ -344,7 +344,7 @@ func (c *DBLClient) HasUserVoted(botID, userID string) (bool, error) {
 }
 
 // Information about a specific bot's stats
-func (c *DBLClient) GetBotStats(botID string) (*BotStats, error) {
+func (c *Client) GetBotStats(botID string) (*BotStats, error) {
 	if c.token == "" {
 		return nil, ErrRequireAuthentication
 	}
@@ -359,7 +359,7 @@ func (c *DBLClient) GetBotStats(botID string) (*BotStats, error) {
 		return nil, err
 	}
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return nil, err
@@ -387,7 +387,7 @@ func (c *DBLClient) GetBotStats(botID string) (*BotStats, error) {
 // Requires authentication
 //
 // If your bot is unsharded, pass in server count as the only item in the slice
-func (c *DBLClient) PostBotStats(botID string, payload BotStatsPayload) error {
+func (c *Client) PostBotStats(botID string, payload *BotStatsPayload) error {
 	if c.token == "" {
 		return ErrRequireAuthentication
 	}
@@ -411,7 +411,7 @@ func (c *DBLClient) PostBotStats(botID string, payload BotStatsPayload) error {
 	req.Header.Set("Authorization", c.token)
 	req.Header.Set("Content-Type", "application/json")
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return err

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,25 @@
+package dbl
+
+import (
+	"log"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewClient(t *testing.T) {
+	const clientTimeout = 5 * time.Second
+
+	httpClient := &http.Client{}
+
+	_, err := NewClient(
+		"token",
+		HTTPClientOption(httpClient), // Setting a custom HTTP client. Default is *http.Client with default timeout.
+		TimeoutOption(clientTimeout), // Setting timeout option. Default is 3 seconds
+	)
+	if err != nil {
+		log.Fatalf("Error creating new Discord Bot List client: %s", err)
+	}
+
+	// ...
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/DiscordBotList/go-dbl
 
 go 1.14
+
+require (
+	github.com/stretchr/testify v1.5.1
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/users.go
+++ b/users.go
@@ -65,7 +65,7 @@ type Social struct {
 }
 
 // Information about a particular user
-func (c *DBLClient) GetUser(UserID string) (*User, error) {
+func (c *Client) GetUser(UserID string) (*User, error) {
 	if c.token == "" {
 		return nil, ErrRequireAuthentication
 	}
@@ -76,7 +76,7 @@ func (c *DBLClient) GetUser(UserID string) (*User, error) {
 		return nil, err
 	}
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return nil, err

--- a/util.go
+++ b/util.go
@@ -11,7 +11,7 @@ type ratelimitResponse struct {
 	RetryAfter int `json:"retry-after"`
 }
 
-func (c *DBLClient) readBody(res *http.Response) ([]byte, error) {
+func (c *Client) readBody(res *http.Response) ([]byte, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode == 401 {
@@ -47,7 +47,7 @@ func (c *DBLClient) readBody(res *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-func (c *DBLClient) createRequest(method, endpoint string, body io.Reader) (*http.Request, error) {
+func (c *Client) createRequest(method, endpoint string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, BaseURL+endpoint, body)
 
 	if err != nil {

--- a/weekend.go
+++ b/weekend.go
@@ -9,7 +9,7 @@ type weekendResponse struct {
 }
 
 // Check if the multiplier is live for the weekend
-func (c *DBLClient) IsMultiplierActive() (bool, error) {
+func (c *Client) IsMultiplierActive() (bool, error) {
 	if c.token == "" {
 		return false, ErrRequireAuthentication
 	}
@@ -20,7 +20,7 @@ func (c *DBLClient) IsMultiplierActive() (bool, error) {
 		return false, err
 	}
 
-	res, err := c.client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Following the existing example of customizing the `*http.Client` via `TimeoutOption` function, this PR includes a new `HTTPClientOption` function to allow  customizing the HTTP client used.

This PR is in support of Issue: https://github.com/DiscordBotList/go-dbl/issues/8

The PR also includes a new unit test to cover the new functionality, as well as updated `README.md` documentation. Some changes are related to best practices outlined in [Effective Go](https://golang.org/doc/effective_go.html) (namely avoiding stuttering by renaming the `DBLClient` struct to just `Client`).